### PR TITLE
Update _index.en.md - lowercase docker tag

### DIFF
--- a/content/basics/build/_index.en.md
+++ b/content/basics/build/_index.en.md
@@ -13,8 +13,8 @@ In order to build the `LocalAI` container image locally you can use `docker`:
 
 ```
 # build the image
-docker build -t LocalAI .
-docker run LocalAI
+docker build -t localai .
+docker run localai
 ```
 
 Or you can build the binary with `make`:


### PR DESCRIPTION
Docker tags should be lowercase, or else build fails