### PR TITLE
doc: reduce default threads in Getting Started

### DIFF
--- a/content/basics/getting_started/_index.en.md
+++ b/content/basics/getting_started/_index.en.md
@@ -176,7 +176,7 @@ Deploy a single LocalAI pod with 6GB of persistent storage serving up a `ggml-gp
 deployment:
   # Adjust the number of threads and context size for model inference
   env:
-    threads: 14
+    threads: 4
     contextSize: 512
 
 # Set the pod requests/limits


### PR DESCRIPTION
14 threads is far too many in most cases and causes confusion with overclocking.