### PR TITLE
Propose a minimal Golang version

### DIFF
--- a/content/basics/build/_index.en.md
+++ b/content/basics/build/_index.en.md
@@ -10,7 +10,7 @@ weight = 3
 Requirements:
 
 Either Docker/podman, or
-- Golang
+- Golang >= 1.20
 - Cmake/make
 - GCC
 


### PR DESCRIPTION
This should be updated to what the actual minimum version is, but it's surely greater than 1.13.

Using the golang included in Ubuntu 20.04.6 fails with

```
build github.com/go-skynet/LocalAI: cannot load embed: malformed module path "embed": missing dot in first path element
make: *** [Makefile:222: build] Error 1
```

This seems to be just due to the old version of Go included in that distro (1.13 I think), and updating to the latest Go version fixed it.