### PR TITLE
Move to `docker compose` for upstream v2 compatibility

### DIFF
--- a/content/getting_started/_index.en.md
+++ b/content/getting_started/_index.en.md
@@ -10,7 +10,7 @@ url = '/basics/getting_started/'
 
 For a step by step how to of setting up LocalAI, Please see our [How to]({{%relref "howtos" %}}) page.
 
-The easiest way to run LocalAI is by using [docker-compose](https://docs.docker.com/compose/install/) or with [docker](https://docs.docker.com/engine/install/) (to build locally, see the [build section]({{%relref "build" %}})). The following example uses `docker-compose`:
+The easiest way to run LocalAI is by using [docker compose](https://docs.docker.com/compose/install/) or with [docker](https://docs.docker.com/engine/install/) (to build locally, see the [build section]({{%relref "build" %}})). The following example uses `docker compose`:
 
 ```bash
 
@@ -27,10 +27,10 @@ cp your-model.bin models/
 # (optional) Edit the .env file to set things like context size and threads
 # vim .env
 
-# start with docker-compose
-docker-compose up -d --pull always
+# start with docker compose
+docker compose up -d --pull always
 # or you can build the images with:
-# docker-compose up -d --build
+# docker compose up -d --build
 
 # Now API is accessible at localhost:8080
 curl http://localhost:8080/v1/models
@@ -43,7 +43,7 @@ curl http://localhost:8080/v1/completions -H "Content-Type: application/json" -d
    }'
 ```
 
-### Example: Use GPT4ALL-J model with `docker-compose`
+### Example: Use GPT4ALL-J model with `docker compose`
 
 
 ```bash
@@ -64,10 +64,10 @@ cp -rf prompt-templates/ggml-gpt4all-j.tmpl models/
 # (optional) Edit the .env file to set things like context size and threads
 # vim .env
 
-# start with docker-compose
-docker-compose up -d --pull always
+# start with docker compose
+docker compose up -d --pull always
 # or you can build the images with:
-# docker-compose up -d --build
+# docker compose up -d --build
 # Now API is accessible at localhost:8080
 curl http://localhost:8080/v1/models
 # {"object":"list","data":[{"id":"ggml-gpt4all-j","object":"model"}]}


### PR DESCRIPTION
docker-compose is dead; long live docker compose

Using the current syntax results in an error: 
![image](https://github.com/go-skynet/localai-website/assets/1383363/7f32bee5-96f3-4f27-afaf-466f7aa943d5)

This PR was just some search and replace to get things working with the newer Docker Compose v2 plugin.